### PR TITLE
refactor: move cfg around to web test only

### DIFF
--- a/rust+wasm/{{project-name}}-wasm/src/lib.rs
+++ b/rust+wasm/{{project-name}}-wasm/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![deny(unreachable_pub, private_in_public)]
-#![cfg(target_arch = "wasm32")]
 
 //! {{project-name}}
 

--- a/rust+wasm/{{project-name}}-wasm/tests/web.rs
+++ b/rust+wasm/{{project-name}}-wasm/tests/web.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 //! Test suite for the Web and headless browsers.
 {% if node-or-web == "nodejs" %}
 use wasm_bindgen_test::wasm_bindgen_test;


### PR DESCRIPTION
this now allows `cargo test` not to interfere w/ wasm tests. 