### PR TITLE
fix: Allow CI continue on Coverage upload fail

### DIFF
--- a/rust+wasm/.github/workflows/coverage.yml
+++ b/rust+wasm/.github/workflows/coverage.yml
@@ -56,7 +56,8 @@ jobs:
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
+        continue-on-error: true
         with:
           token: {{ "${{ secrets.CODECOV_TOKEN " }}}}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: lcov.info

--- a/rust/.github/workflows/coverage.yml
+++ b/rust/.github/workflows/coverage.yml
@@ -55,7 +55,8 @@ jobs:
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
+        continue-on-error: true
         with:
           token: {{ "${{ secrets.CODECOV_TOKEN " }}}}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: lcov.info


### PR DESCRIPTION
# Description

The CI fails if the coverage report upload fails

## Link to issue

Fixes #56 

## Type of change

- [X ] Bug fix (non-breaking change that fixes an issue)

