### PR TITLE
fix: Free from time 0.1 dependency

### DIFF
--- a/examples/gen-axum/Cargo.toml
+++ b/examples/gen-axum/Cargo.toml
@@ -37,7 +37,7 @@ async-trait = "0.1"
 axum = { version = "0.6", features = ["headers"] }
 axum-tracing-opentelemetry = { version = "0.9", features = ["otlp"] }
 base64 = "0.21"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 config = "0.13"
 console-subscriber = { version = "0.1", default-features = false, features = [ "parking_lot" ], optional = true }
 const_format = "0.2"

--- a/examples/gen-axum/deny.toml
+++ b/examples/gen-axum/deny.toml
@@ -47,9 +47,8 @@ yanked = "deny"
 notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = [
-    "RUSTSEC-2020-0071" # time 0.1 w/ chrono
-]
+#ignore = [
+#]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
 # will still output a note when they are encountered.

--- a/rust+wasm/{{project-name}}/Cargo.axum.toml
+++ b/rust+wasm/{{project-name}}/Cargo.axum.toml
@@ -43,7 +43,7 @@ async-trait = "0.1"
 axum = { version = "0.6", features = ["headers"] }
 axum-tracing-opentelemetry = { version = "0.9", features = ["otlp"] }
 base64 = "0.21"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 config = "0.13"
 console-subscriber = { version = "0.1", default-features = false, features = [ "parking_lot" ], optional = true }
 const_format = "0.2"

--- a/rust/Cargo.axum.toml
+++ b/rust/Cargo.axum.toml
@@ -50,7 +50,7 @@ async-trait = "0.1"
 axum = { version = "0.6", features = ["headers"] }
 axum-tracing-opentelemetry = { version = "0.9", features = ["otlp"] }
 base64 = "0.21"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 config = "0.13"
 console-subscriber = { version = "0.1", default-features = false, features = [ "parking_lot" ], optional = true }
 const_format = "0.2"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -47,9 +47,8 @@ yanked = "deny"
 notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = [
-    "RUSTSEC-2020-0071" # time 0.1 w/ chrono
-]
+#ignore = [
+#]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
 # will still output a note when they are encountered.


### PR DESCRIPTION
# Description

time 0.1 is brought by chrono oldtime feature which is going away in chrono 0.5 some day

Time 0.1 also triggered the RUSTSEC due to it's lack of thread safety via std

Chrono's oldtime has been RiR'd and is exposed when not using default features that oldtime is part of

Chrono's oldtime is in default features due to 0.4 SemVer compatibility as it was exposed but it's not an issue here and can just use the clock feature for Utc

## Type of change

- [X ] Bug fix (non-breaking change that fixes an issue)