### PR TITLE
chore: Update environment variable seperator comment to indicate double underscore

### DIFF
--- a/rust/src.axum/settings.rs
+++ b/rust/src.axum/settings.rs
@@ -104,8 +104,8 @@ impl Settings {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config/settings.toml");
         // inject environment variables naming them properly on the settings
         // e.g. [database] url="foo"
-        // would be injected with environment variable APP_DATABASE_URL="foo"
-        // use one underscore as defined by the separator below
+        // would be injected with environment variable APP__DATABASE__URL="foo"
+        // using a double underscore as defined by the separator below
         let s = Config::builder()
             .add_source(File::with_name(&path.as_path().display().to_string()))
             .add_source(Environment::with_prefix("APP").separator("__"))


### PR DESCRIPTION
# Description

This PR makes the following changes:

- [ ] ~~Update environment variable separator to one underscore~~ It should be a double underscore!
- [x] Update comment to indicate a double underscore should be used 

## Type of change

- [x] Documentation

## Test plan (required)

No test, check the updated comment.
