### PR TITLE
Fix build warnings and lints

### DIFF
--- a/rust+wasm/deny.toml
+++ b/rust+wasm/deny.toml
@@ -50,6 +50,8 @@ notice = "warn"
 ignore = [
     "RUSTSEC-2023-0071", # Impacts rsa crate, which is only used in dev, see
                          # https://github.com/RustCrypto/RSA/pull/394 for remediation
+    "RUSTSEC-2024-0336", # Ignore a DOS issue w/ rustls-0.20.9. This will go
+                         # away when we update opentelemetry-otlp soon.
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/rust+wasm/deny.toml
+++ b/rust+wasm/deny.toml
@@ -48,7 +48,8 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2020-0071" # time 0.1 w/ chrono
+    "RUSTSEC-2023-0071", # Impacts rsa crate, which is only used in dev, see
+                         # https://github.com/RustCrypto/RSA/pull/394 for remediation
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/rust+wasm/deny.toml
+++ b/rust+wasm/deny.toml
@@ -48,10 +48,13 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    "RUSTSEC-2021-0145", # atty on windows only
     "RUSTSEC-2023-0071", # Impacts rsa crate, which is only used in dev, see
                          # https://github.com/RustCrypto/RSA/pull/394 for remediation
     "RUSTSEC-2024-0336", # Ignore a DOS issue w/ rustls-0.20.9. This will go
                          # away when we update opentelemetry-otlp soon.
+    { id = "RUSTSEC-2020-0168", reason = "Not planning to force upgrade to mach2 yet" },
+    { id = "RUSTSEC-2024-0320", reason = "Not planning to force upgrade to rust-yaml2 yet" },
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -114,32 +117,23 @@ exceptions = [
     # included in the application. We do not distribute those data files so
     # this is not a problem for us. See https://github.com/dtolnay/unicode-ident/pull/9/files
     { allow = ["Unicode-DFS-2016"], name = "unicode-ident", version = "*"},
+    { allow = ["OpenSSL"], name = "ring", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-#[[licenses.clarify]]
-# The name of the crate the clarification applies to
-#name = "ring"
-# The optional version constraint for the crate
-#version = "*"
-# The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
-# One or more files in the crate's source used as the "source of truth" for
-# the license expression. If the contents match, the clarification will be used
-# when running the license check, otherwise the clarification will be ignored
-# and the crate will be checked normally, which may produce warnings or errors
-# depending on the rest of your configuration
-#license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
 # published to private registries
-ignore = false
+ignore = true
 # One or more private registries that you might publish crates to, if a crate
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked

--- a/rust+wasm/deny.toml
+++ b/rust+wasm/deny.toml
@@ -36,15 +36,15 @@ db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # The lint level for security vulnerabilities
-vulnerability = "deny"
+# vulnerability = "deny"
 # The lint level for unmaintained crates
-unmaintained = "warn"
+# unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry
-yanked = "deny"
+# yanked = "deny"
 # The lint level for crates with security notices. Note that as of
 # 2019-12-17 there are no security notice advisories in
 # https://github.com/rustsec/advisory-db
-notice = "warn"
+# notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -68,7 +68,7 @@ ignore = [
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
 # The lint level for crates which do not have a detectable license
-unlicensed = "warn"
+# unlicensed = "warn"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
@@ -84,23 +84,23 @@ allow = [
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-deny = [
+# deny = [
     #"Nokia",
-]
+# ]
 # Lint level for licenses considered copyleft
-copyleft = "deny"
+# copyleft = "deny"
 # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
 # * both - The license will be approved if it is both OSI-approved *AND* FSF
 # * either - The license will be approved if it is either OSI-approved *OR* FSF
 # * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
 # * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
 # * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
+# allow-osi-fsf-free = "neither"
 # Lint level used when no other predicates are matched
 # 1. License isn't in the allow or deny lists
 # 2. License isn't copyleft
 # 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
+# default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -139,7 +139,7 @@ exceptions = [
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
 # published to private registries
-ignore = true
+ignore = false
 # One or more private registries that you might publish crates to, if a crate
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked

--- a/rust+wasm/{{project-name}}-wasm/src/lib.rs
+++ b/rust+wasm/{{project-name}}-wasm/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
+#![deny(private_bounds)]
+#![deny(rustdoc::private_intra_doc_links)]
+#![deny(private_interfaces)]
 
 //! {{project-name}}
 

--- a/rust+wasm/{{project-name}}/Cargo.axum.toml
+++ b/rust+wasm/{{project-name}}/Cargo.axum.toml
@@ -109,3 +109,6 @@ test_utils = ["proptest"]{% endif %}
 all-features = true
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/rust+wasm/{{project-name}}/src.axum/extract/json.rs
+++ b/rust+wasm/{{project-name}}/src.axum/extract/json.rs
@@ -30,7 +30,7 @@ use crate::error::AppError;
 /// - The request doesn't have a `Content-Type: application/json` (or similar) header.
 /// - The body doesn't contain syntactically valid JSON.
 /// - The body contains syntactically valid JSON but it couldn't be deserialized into the target
-/// type.
+///   type.
 /// - Buffering the request body fails.
 ///
 /// See [AppError] for more details.

--- a/rust+wasm/{{project-name}}/src.axum/headers/header.rs
+++ b/rust+wasm/{{project-name}}/src.axum/headers/header.rs
@@ -54,6 +54,7 @@ macro_rules! header {
 
 /// Trait for returning header value directly for passing
 /// along to client calls.
+#[allow(unused)]
 pub(crate) trait HeaderValue {
     fn header_value(&self) -> String;
 }

--- a/rust+wasm/{{project-name}}/src.axum/lib.rs
+++ b/rust+wasm/{{project-name}}/src.axum/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
+#![deny(private_bounds)]
+#![deny(rustdoc::private_intra_doc_links)]
+#![deny(private_interfaces)]
 
 //! {{project-name}}
 

--- a/rust+wasm/{{project-name}}/src.axum/middleware/logging.rs
+++ b/rust+wasm/{{project-name}}/src.axum/middleware/logging.rs
@@ -279,7 +279,7 @@ async fn log_reqwest_response(
             .headers_mut()
             .ok_or_else(|| anyhow!("failed to convert response headers"))?;
 
-        headers.extend(headers_iter.map(|(k, v)| (k, v)));
+        headers.extend(headers_iter);
 
         let res = builder.body(body)?;
         Ok(reqwest::Response::from(res))

--- a/rust+wasm/{{project-name}}/src.axum/middleware/reqwest_retry.rs
+++ b/rust+wasm/{{project-name}}/src.axum/middleware/reqwest_retry.rs
@@ -51,10 +51,10 @@ static MAXIMUM_NUMBER_OF_RETRIES: u32 = 10;
 ///
 /// Some workaround suggestions:
 /// * If you can fit the data in memory, you can instead build static request bodies e.g. with
-/// `Body`'s `From<String>` or `From<Bytes>` implementations.
+///   `Body`'s `From<String>` or `From<Bytes>` implementations.
 /// * You can wrap this middleware in a custom one which skips retries for streaming requests.
 /// * You can write a custom retry middleware that builds new streaming requests from the data
-/// source directly, avoiding the issue of streaming requests not being clonable.
+///   source directly, avoiding the issue of streaming requests not being clonable.
 #[derive(Debug)]
 pub struct RetryTransientMiddleware<T: RetryPolicy + Send + Sync + 'static> {
     client_name: String,

--- a/rust+wasm/{{project-name}}/src/lib.rs
+++ b/rust+wasm/{{project-name}}/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
+#![deny(private_bounds)]
+#![deny(rustdoc::private_intra_doc_links)]
+#![deny(private_interfaces)]
 
 //! {{project-name}}
 {% if bench %}

--- a/rust/Cargo.axum.toml
+++ b/rust/Cargo.axum.toml
@@ -121,3 +121,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 # See https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#splitting-debug-information
 [profile.dev]
 split-debuginfo = "unpacked"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -50,6 +50,8 @@ notice = "warn"
 ignore = [
     "RUSTSEC-2023-0071", # Impacts rsa crate, which is only used in dev, see
                          # https://github.com/RustCrypto/RSA/pull/394 for remediation
+    "RUSTSEC-2024-0336", # Ignore a DOS issue w/ rustls-0.20.9. This will go
+                         # away when we update opentelemetry-otlp soon.
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -48,10 +48,13 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    "RUSTSEC-2021-0145", # atty on windows only
     "RUSTSEC-2023-0071", # Impacts rsa crate, which is only used in dev, see
                          # https://github.com/RustCrypto/RSA/pull/394 for remediation
     "RUSTSEC-2024-0336", # Ignore a DOS issue w/ rustls-0.20.9. This will go
                          # away when we update opentelemetry-otlp soon.
+    { id = "RUSTSEC-2020-0168", reason = "Not planning to force upgrade to mach2 yet" },
+    { id = "RUSTSEC-2024-0320", reason = "Not planning to force upgrade to rust-yaml2 yet" },
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -114,32 +117,23 @@ exceptions = [
     # included in the application. We do not distribute those data files so
     # this is not a problem for us. See https://github.com/dtolnay/unicode-ident/pull/9/files
     { allow = ["Unicode-DFS-2016"], name = "unicode-ident", version = "*"},
+    { allow = ["OpenSSL"], name = "ring", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-#[[licenses.clarify]]
-# The name of the crate the clarification applies to
-#name = "ring"
-# The optional version constraint for the crate
-#version = "*"
-# The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
-# One or more files in the crate's source used as the "source of truth" for
-# the license expression. If the contents match, the clarification will be used
-# when running the license check, otherwise the clarification will be ignored
-# and the crate will be checked normally, which may produce warnings or errors
-# depending on the rest of your configuration
-#license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
 # published to private registries
-ignore = false
+ignore = true
 # One or more private registries that you might publish crates to, if a crate
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -36,15 +36,15 @@ db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # The lint level for security vulnerabilities
-vulnerability = "deny"
+# vulnerability = "deny"
 # The lint level for unmaintained crates
-unmaintained = "warn"
+# unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry
-yanked = "deny"
+# yanked = "deny"
 # The lint level for crates with security notices. Note that as of
 # 2019-12-17 there are no security notice advisories in
 # https://github.com/rustsec/advisory-db
-notice = "warn"
+# notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -68,7 +68,7 @@ ignore = [
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
 # The lint level for crates which do not have a detectable license
-unlicensed = "warn"
+# unlicensed = "warn"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
@@ -84,23 +84,23 @@ allow = [
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-deny = [
+# deny = [
     #"Nokia",
-]
+# ]
 # Lint level for licenses considered copyleft
-copyleft = "deny"
+# copyleft = "deny"
 # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
 # * both - The license will be approved if it is both OSI-approved *AND* FSF
 # * either - The license will be approved if it is either OSI-approved *OR* FSF
 # * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
 # * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
 # * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
+# allow-osi-fsf-free = "neither"
 # Lint level used when no other predicates are matched
 # 1. License isn't in the allow or deny lists
 # 2. License isn't copyleft
 # 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
+# default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -47,8 +47,10 @@ yanked = "deny"
 notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-#ignore = [
-#]
+ignore = [
+    "RUSTSEC-2023-0071", # Impacts rsa crate, which is only used in dev, see
+                         # https://github.com/RustCrypto/RSA/pull/394 for remediation
+]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
 # will still output a note when they are encountered.

--- a/rust/src.axum/extract/json.rs
+++ b/rust/src.axum/extract/json.rs
@@ -30,7 +30,7 @@ use crate::error::AppError;
 /// - The request doesn't have a `Content-Type: application/json` (or similar) header.
 /// - The body doesn't contain syntactically valid JSON.
 /// - The body contains syntactically valid JSON but it couldn't be deserialized into the target
-/// type.
+///   type.
 /// - Buffering the request body fails.
 ///
 /// See [AppError] for more details.

--- a/rust/src.axum/headers/header.rs
+++ b/rust/src.axum/headers/header.rs
@@ -54,6 +54,7 @@ macro_rules! header {
 
 /// Trait for returning header value directly for passing
 /// along to client calls.
+#[allow(unused)]
 pub(crate) trait HeaderValue {
     fn header_value(&self) -> String;
 }

--- a/rust/src.axum/lib.rs
+++ b/rust/src.axum/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![deny(unreachable_pub)]
+#![deny(private_bounds)]
+#![deny(rustdoc::private_intra_doc_links)]
+#![deny(private_interfaces)]
 
 //! {{project-name}}
 

--- a/rust/src.axum/main.rs
+++ b/rust/src.axum/main.rs
@@ -12,9 +12,7 @@ use std::{
 };
 use tokio::signal;
 #[cfg(unix)]
-use tokio::signal::{
-    unix::{signal, SignalKind},
-};
+use tokio::signal::unix::{signal, SignalKind};
 use tower::ServiceBuilder;
 use tower_http::{
     catch_panic::CatchPanicLayer, sensitive_headers::SetSensitiveHeadersLayer,

--- a/rust/src.axum/middleware/logging.rs
+++ b/rust/src.axum/middleware/logging.rs
@@ -279,7 +279,7 @@ async fn log_reqwest_response(
             .headers_mut()
             .ok_or_else(|| anyhow!("failed to convert response headers"))?;
 
-        headers.extend(headers_iter.map(|(k, v)| (k, v)));
+        headers.extend(headers_iter);
 
         let res = builder.body(body)?;
         Ok(reqwest::Response::from(res))

--- a/rust/src.axum/middleware/reqwest_retry.rs
+++ b/rust/src.axum/middleware/reqwest_retry.rs
@@ -51,10 +51,10 @@ static MAXIMUM_NUMBER_OF_RETRIES: u32 = 10;
 ///
 /// Some workaround suggestions:
 /// * If you can fit the data in memory, you can instead build static request bodies e.g. with
-/// `Body`'s `From<String>` or `From<Bytes>` implementations.
+///   `Body`'s `From<String>` or `From<Bytes>` implementations.
 /// * You can wrap this middleware in a custom one which skips retries for streaming requests.
 /// * You can write a custom retry middleware that builds new streaming requests from the data
-/// source directly, avoiding the issue of streaming requests not being clonable.
+///   source directly, avoiding the issue of streaming requests not being clonable.
 #[derive(Debug)]
 pub struct RetryTransientMiddleware<T: RetryPolicy + Send + Sync + 'static> {
     client_name: String,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![deny(unreachable_pub)]
+#![deny(private_bounds)]
+#![deny(rustdoc::private_intra_doc_links)]
+#![deny(private_interfaces)]
 
 //! {{project-name}}
 {% if bench %}


### PR DESCRIPTION
# Description

Breaking my other PR (#183) into a few smaller segments that are easier to merge. This segment fixes several lints, format errors, etc. just to get the current build CI to green for all steps.

The lints include:
- Replace warnings for private_in_public with new warning groups
- Ignore the security warning from the rsa package. It's only used in dev right now
- Ignore the security warning form rustls. We're going to fix that warning once we upgrade the opentelemetry packages
- Fix a code lint around unused HeaderValue in the header macro
- Fix a code lint around using an identity function in a map.

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

Run through CI and validated that all CI steps now pass with greens.
